### PR TITLE
send reminder emails to candidates with new activity

### DIFF
--- a/q_and_a/apps/candidates/management/commands/remind_candidates.py
+++ b/q_and_a/apps/candidates/management/commands/remind_candidates.py
@@ -1,0 +1,54 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+from candidates.models import Candidate
+from questions.models import Answer
+from django.core.mail import EmailMultiAlternatives, get_connection
+from django.template.loader import render_to_string
+
+from django.conf import settings
+
+def make_email(candidate):
+    subject = u'New questions for ' + candidate.constituency_name + u' candidates'
+    email_from = u'questions@campaignreply.org'
+    to = candidate.contact_address
+
+    text_content = render_to_string('candidates/reminder.txt', {'candidate': candidate})
+    html_content = render_to_string('candidates/reminder.html', {'candidate': candidate})
+    msg = EmailMultiAlternatives(subject, text_content, email_from, [to])
+    msg.attach_alternative(html_content, 'text/html')
+    return msg
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        """Send a reminder email to participating candidates who haven't answered a question
+        in <n> days, but have more questions to answer"""
+
+        candidates_with_email = [candidate for candidate in Candidate.objects.all()
+                                 if candidate.contact_address and candidate.participating]
+
+        reply = raw_input(u'this will e-mail up to {} candidates, are you sure? [y/n] '.format(len(candidates_with_email)))
+        if not reply or reply[0].lower() != u'y':
+            return
+
+        #cutoff date is defined in settings
+        reminder_date = datetime.date.today() - datetime.timedelta(settings.REMINDER_TIME_PERIOD)
+
+        print 'sending e-mails'
+        conn = get_connection()
+        for c in candidates_with_email:
+            # consider moving this check to a model method to allow testing
+
+            last_answer = Answer.objects.filter(candidate=c,completed=True).aggregate(Max('completed_timestamp'))['completed_timestamp__max']
+            open_questions = c.get_open_question_count()
+            print "Candidate: ", c, "; Last answer: ", last_answer, "; Open questions: ", open_questions
+
+            if last_answer is None: # don't send to people who haven't answered a question ever
+                continue
+            if last_answer <= reminder_date and open_questions > 0:
+
+                print 'emailing', c
+                msg = make_email(c)
+                conn.send_messages([msg])
+        conn.close()

--- a/q_and_a/settings/base.py
+++ b/q_and_a/settings/base.py
@@ -175,6 +175,9 @@ LOGGING = {
 
 # EMAILS
 
+# reminder email time interval in days
+REMINDER_TIME_PERIOD=7
+
 # CANDIDATE CONFIG
 
 OPEN_QUESTION_TARGET = 10

--- a/q_and_a/templates/candidates/reminder.html
+++ b/q_and_a/templates/candidates/reminder.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+<title>New questions for {{ candidate.constituency_name }} candidates</title>
+</head>
+<body>
+
+
+<p>Dear {{candidate.name}},</p>
+
+<p>Once again, thank you for participating.  It's been a few days since your
+last visit, and we thought that you'd like to know that there are more
+questions for you from various organisations.</p>
+
+<p>To go back to the site and review the questions, please click on the
+unique link below:</p>
+
+<p><a href="http://questions.campaignreply.org/candidates/authenticate/{{ candidate.auth_token }}">Answer Questions</a></p>
+
+
+<p>Best regards</p>
+
+
+</body>
+</html>

--- a/q_and_a/templates/candidates/reminder.txt
+++ b/q_and_a/templates/candidates/reminder.txt
@@ -1,0 +1,16 @@
+
+Dear {{candidate.name}},
+
+Once again, thank you for participating.  It's been a few days since your
+last visit, and we thought that you'd like to know that there are more
+questions for you from various organisations.
+
+To go back to the site and review the questions, please click on the
+unique link below:
+
+http://questions.campaignreply.org/candidates/authenticate/{{ candidate.auth_token }}
+
+Best regards
+
+
+


### PR DESCRIPTION
A management command that sends reminder emails to candidates.  The email content will need to be reviewed for style compliance, but the rest is working.
