### PR TITLE
Remove answers from constituency pages

### DIFF
--- a/functional_tests/test_candidate_details.py
+++ b/functional_tests/test_candidate_details.py
@@ -1,0 +1,68 @@
+from .base import FunctionalTest
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+
+
+class CandidateDetailsTest(FunctionalTest):
+
+    fixtures = ['ft-data.json']
+
+    def test_answers_appear_on_candidate_details_page(self):
+
+        # I visit the page for my constituency directly.
+        constituency_url = (self.live_server_url + '/constituencies/65787/')
+        self.browser.get(constituency_url)
+
+        # I can see the name of my constituency.
+        self.check_for_strings_in_page_element('h1', 'Brighton, Pavilion')
+
+        # I am thinking of voting for Purna Sen so I click
+        # on her name.
+        candidate_1_link = self.browser.find_element_by_link_text('Purna Sen')
+        candidate_1_link.click()
+
+        # I am taken to a new URL
+        self.assertEqual(self.browser.current_url,
+            self.live_server_url + '/candidates/view_answer/4279'
+        )
+
+        # The newpage shows Purna's name, party and constituency.
+        self.check_for_strings_in_page_element('body', {
+            'Purna Sen',
+            'Brighton, Pavilion',
+            'Labour Party',
+        })
+
+        # I can see the questions asked of Purna.
+        self.check_for_strings_in_page_element('body', {
+            'What is the meaning of life?',
+            'What is your quest?',
+        })
+
+        # I can see her answers to each question.
+        self.check_for_strings_in_page_element('body', {
+            'Lorem Ipsum is not simply random text.',
+            'To find the Holy Grail',
+        })
+
+        # I can see which organisation asked each question.
+        self.check_for_strings_in_page_element('body', {
+            'The Very Organisation',
+            'The Quite Organisation',
+        })
+
+        # No unanswered questions appear.
+        self.fail('Finish the test!')
+
+        # I decide to review the answers from another candidate
+        # in my constituency so I click a link to return to the
+        # constituency page
+
+        # I click on Caroline Lucas's name. I am taken to a new URL.
+        # I can see Carorline's details on the page.
+        # I can see the questions asked of Caroline.
+        # I can see her answers to each question.
+        # I can see which organisation asked each question.
+        # None of the details for Purna appear on the page.
+
+        # Having made my decision, I go back to sleep.

--- a/functional_tests/test_constituency.py
+++ b/functional_tests/test_constituency.py
@@ -3,14 +3,15 @@ from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
-class VoterTest(FunctionalTest):
+class ConstituencyTest(FunctionalTest):
 
     fixtures = ['ft-data.json']
 
-    def test_view_answers(self):
-        # So that I can decide for whom to vote
+    def test_view_constituency(self):
+        # So that I can discover answers from relevant candidates
         # As a voter
-        # I want to read the answers given by candidates in my constituency
+        # I want to see which candidates in my costituency have answered
+        # questions.
 
         # I visit the homepage and am invited to enter my postcode
         self.browser.get(self.live_server_url)
@@ -23,7 +24,7 @@ class VoterTest(FunctionalTest):
         # I type in my postcode
         inputbox.send_keys('SW1A 0AA')
 
-        # When I hit enter, I am taken to a new URL, and now the page 
+        # When I hit enter, I am taken to a new URL, and now the page
         # shows the constituency for my postcode
         inputbox.send_keys(Keys.ENTER)
         voter1_wmc_url = self.browser.current_url
@@ -37,17 +38,17 @@ class VoterTest(FunctionalTest):
         self.browser.quit()
         self.browser = webdriver.Firefox()
 
-        # The second user visits the home page. There is no sign of 
+        # The second user visits the home page. There is no sign of
         # my constituency information.
         self.browser.get(self.live_server_url)
         page_text = self.browser.find_element_by_tag_name('body').text
-        self.assertNotIn('Cties of London and Westminster', page_text)
+        self.assertNotIn('Cities of London and Westminster', page_text)
 
         # They type in their postcode and press enter
         inputbox = self.browser.find_element_by_id('id_postcode')
         inputbox.send_keys('bn1 1ee')
         inputbox.send_keys(Keys.ENTER)
-        
+
         # They are taken to a new URL, and now the page shows the
         # constituency for their postcode
         voter2_wmc_url = self.browser.current_url
@@ -59,8 +60,8 @@ class VoterTest(FunctionalTest):
 
         # Again, there is no trace of my constituency on their page
         page_text = self.browser.find_element_by_tag_name('body').text
-        self.assertNotIn('Cties of London and Westminster', page_text)
-        
+        self.assertNotIn('Cities of London and Westminster', page_text)
+
         # They can see which candidates are standing in their constituency
         self.check_for_strings_in_page_element('body', {
             'Chris Bowers',
@@ -70,28 +71,6 @@ class VoterTest(FunctionalTest):
             'Howard Pilott',
             'Purna Sen',
             'Nick Yeomans',
-        })
-
-        # They can see the questions asked of each candidate
-        self.check_for_strings_in_page_element('body', {
-            'What is the meaning of life?',
-            'How many grains of sand are there under the sea?',
-            'What is your name?',
-            'What is your quest?',
-        })
-
-        # They can see each candidate's answers to each question
-        self.check_for_strings_in_page_element('body', {
-            '42',
-            'I don\'t know.',
-            'To find the Holy Grail',
-            'Too many',
-        })
-
-        # They can see which organisation asked each question
-        self.check_for_strings_in_page_element('body', {
-            'The Very Organisation',
-            'The Quite Organisation',
         })
 
         # Satisfied, they and I go back to sleep

--- a/q_and_a/apps/voters/templates/constituency.html
+++ b/q_and_a/apps/voters/templates/constituency.html
@@ -4,32 +4,20 @@
 
   <h1>{{ constituency }}</h1>
 
+  <h2>Candidates</h2>
+
   <ul>
     {% for candidate in candidates %}
-      <li>{{ candidate }}</li>
+    <li><a href="/candidates/view_answer/{{candidate.popit_id}}">{{ candidate.name }}</a></li>
     {% endfor %}
   </ul>
-
-  <form method="POST" action="/">
-    <input name="postcode" id="id_postcode" placeholder="Enter your postcode" />
-    {% csrf_token %}
-  </form>
 
 {% endblock jumbotron %}
 
 {% block content %}
-
-  {% for candidate in candidates %}
-    <h2>{{ candidate.name }}</h2>
-    {% for organisation in organisations %}
-      <h3>Questions from {{ organisation.name }}</h3>
-      {% for answer in answers %}
-        {% if answer.candidate == candidate and answer.question.organisation == organisation %}
-          <h4>{{ answer.question.question }}</h4>
-          <p>{{ answer.answer }}</p>
-        {% endif %}
-      {% endfor %}
-    {% endfor %}
-  {% endfor %}
-
+<h2>Search for another constituency</h2>
+<form method="POST">
+  <input name="postcode" id="id_postcode" placeholder="Enter your postcode" />
+  {% csrf_token %}
+</form>
 {% endblock content %}

--- a/q_and_a/apps/voters/tests/tests.py
+++ b/q_and_a/apps/voters/tests/tests.py
@@ -151,12 +151,3 @@ class ConstituencyViewTest(TestCase):
 
         self.assertContains(response, 'Baldrick')
         self.assertContains(response, 'Pitt the Even Younger')
-
-    def test_displays_answers_for_constituency(self):
-        response = self.client.get('/constituencies/%d/' % (self.wmc.constituency_id,))
-
-        self.assertContains(response, 'Answer 1')
-        self.assertContains(response, 'Answer 2')
-        self.assertContains(response, 'Answer 3')
-        self.assertContains(response, 'Answer A')
-        self.assertContains(response, 'Answer B')


### PR DESCRIPTION
- Link to candidate pages from constituency pages
- Remove answers from constituency page
- Tidy up constituency template a bit

Making use of the new view_answer page added by @EdwardBetts, this change resolves the whole mess I created around how to sort candidates, organisations, questions and answers into a sensible order on a single page.
