### PR TITLE
Fix UT to pass badge counts to homepage template

### DIFF
--- a/q_and_a/apps/constituencies/tests/tests.py
+++ b/q_and_a/apps/constituencies/tests/tests.py
@@ -20,7 +20,10 @@ class HomePageTest(TestCase):
     def test_homepage_returns_correct_html(self):
         request = HttpRequest()
         response = HomePageView(request)
-        expected_html = render_to_string('home.html')
+        expected_html = render_to_string('home.html', {
+            'candidates_involved': 0,
+            'questions_answered': 0,
+        })
         self.assertEqual(response.content.decode(), expected_html)
 
 


### PR DESCRIPTION
The unit tests were failing because the homepage template now requires values for two variables: candidates_involved and questions_answered. This patch supplies zero for each.
