### PR TITLE
Fix DoesNotExist exceptions for invalid or missing constituencies

### DIFF
--- a/q_and_a/apps/constituencies/tests/tests.py
+++ b/q_and_a/apps/constituencies/tests/tests.py
@@ -61,14 +61,13 @@ class LookUpConstituencyTest(TestCase):
 
         self.assertEqual(Constituency.objects.count(), 1)
 
-    def test_homepage_handles_invalid_input(self):
+    def test_homepage_handles_invalid_postcode(self):
         response = self.client.post(
             '/',
             data={'postcode': 'not a postcode'}
         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, '/')
+        self.assertEqual(response.status_code, 404)
 
 
 class ConstituencyModelTest(TestCase):
@@ -151,3 +150,13 @@ class ConstituencyViewTest(TestCase):
 
         self.assertContains(response, 'Baldrick')
         self.assertContains(response, 'Pitt the Even Younger')
+
+    def test_handles_invalid_constituency(self):
+        response = self.client.post('/constituencies/asdfghjkl/')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_valid_constituency_not_in_database(self):
+        response = self.client.post('/constituencies/65993/')
+
+        self.assertEqual(response.status_code, 404)

--- a/q_and_a/apps/constituencies/views.py
+++ b/q_and_a/apps/constituencies/views.py
@@ -1,8 +1,9 @@
 from urllib2 import urlopen, HTTPError, URLError
 import json
 
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.db import IntegrityError
+from django.http import Http404
 
 from constituencies.models import Constituency
 from candidates.models import Candidate
@@ -42,7 +43,7 @@ def HomePageView(request):
             )
             return redirect('/constituencies/%d/' % (wmc.constituency_id,))
         else:
-            return redirect('/')
+            raise Http404("Constituency not found")
 
     candidates_involved = Candidate.objects.filter(answer__completed=True).distinct().count()
     questions_answered = Answer.objects.filter(completed=True).count()
@@ -53,7 +54,7 @@ def HomePageView(request):
     })
 
 def ConstituencyView(request, wmc_id):
-    wmc_name = Constituency.objects.get(constituency_id=wmc_id).name
+    wmc_name = get_object_or_404(Constituency, constituency_id=wmc_id).name
     candidates = Candidate.objects.filter(constituency_id=wmc_id)
     answers = Answer.objects.filter(candidate__constituency_id=wmc_id)
     questions = Question.objects.filter(answer__candidate__constituency_id=wmc_id).distinct()


### PR DESCRIPTION
- 404 if search criterion is not a valid postcode.
- 404 if constituency URL accessed directly but constituency not in database.
- 404 if constituency URL accessed directly and constituency part is not valid.
