### PR TITLE
Change menu link text for homepage

### DIFF
--- a/q_and_a/templates/base.html
+++ b/q_and_a/templates/base.html
@@ -28,7 +28,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{% url "home" %}">Ask your candidate</a>
+          <a class="navbar-brand" href="{% url "home" %}">Home</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Received feedback that "Ask your candidate" implied voters
could ask questions via the site. Changing to something more
neutral to avoid this.
