### PR TITLE
Fix functional and unit-tests after recent changes

### DIFF
--- a/functional_tests/test_candidate_details.py
+++ b/functional_tests/test_candidate_details.py
@@ -52,7 +52,6 @@ class CandidateDetailsTest(FunctionalTest):
         })
 
         # No unanswered questions appear.
-        self.fail('Finish the test!')
 
         # I decide to review the answers from another candidate
         # in my constituency so I click a link to return to the

--- a/functional_tests/test_constituency.py
+++ b/functional_tests/test_constituency.py
@@ -37,13 +37,12 @@ class ConstituencyTest(FunctionalTest):
         # They can see:
         #   which candidates are standing in their constituency, and;
         #   to which party each belongs; and
-        #   either the number of questions each has answered, or;
-        #   that the candidate has chosen not to participate.
+        #   the number of questions each has answered.
         self.check_for_strings_in_page_element('body', {
             'Chris Bowers (Liberal Democrats / 2 questions answered)',
             'Nigel Carter (UK Independence Party (UKIP) / 2 questions answered)',
             'Caroline Lucas (Green Party / 2 questions answered)',
-            'Clarence Mitchell (Conservative Party / Not participating)',
+            'Clarence Mitchell (Conservative Party / 2 questions answered)',
             'Howard Pilott (The Socialist Party of Great Britain / 2 questions answered)',
             'Purna Sen (Labour Party / 2 questions answered)',
             'Nick Yeomans (Independent / 1 questions answered)',

--- a/q_and_a/apps/constituencies/tests/tests.py
+++ b/q_and_a/apps/constituencies/tests/tests.py
@@ -163,11 +163,12 @@ class ConstituencyViewTest(TestCase):
         self.assertTemplateUsed(response, 'constituency.html')
 
     def test_displays_correct_constituency_name(self):
-        other_wmc = Constituency.objects.create(constituency_id=2, name='Other Constituency')
+        correct_wmc = Constituency.objects.create(constituency_id=2, name='Correct Constituency')
+        other_wmc = Constituency.objects.create(constituency_id=3, name='Other Constituency')
 
-        response = self.client.get('/constituencies/%d/' % (self.wmc.constituency_id,))
+        response = self.client.get('/constituencies/%d/' % (correct_wmc.constituency_id,))
 
-        self.assertContains(response, 'Dunny-on-the-Wold')
+        self.assertContains(response, 'Correct Constituency')
         self.assertNotContains(response,'Other Constituency')
 
     def test_displays_candidates_for_constituency(self):

--- a/q_and_a/apps/constituencies/tests/tests.py
+++ b/q_and_a/apps/constituencies/tests/tests.py
@@ -163,12 +163,11 @@ class ConstituencyViewTest(TestCase):
         self.assertTemplateUsed(response, 'constituency.html')
 
     def test_displays_correct_constituency_name(self):
-        correct_wmc = Constituency.objects.create(constituency_id=2, name='Correct Constituency')
-        other_wmc = Constituency.objects.create(constituency_id=3, name='Other Constituency')
+        other_wmc = Constituency.objects.create(constituency_id=2, name='Other Constituency')
 
-        response = self.client.get('/constituencies/%d/' % (correct_wmc.constituency_id,))
+        response = self.client.get('/constituencies/%d/' % (self.wmc.constituency_id,))
 
-        self.assertContains(response, 'Correct Constituency')
+        self.assertContains(response, 'Dunny-on-the-Wold')
         self.assertNotContains(response,'Other Constituency')
 
     def test_displays_candidates_for_constituency(self):

--- a/q_and_a/apps/constituencies/tests/tests.py
+++ b/q_and_a/apps/constituencies/tests/tests.py
@@ -215,6 +215,6 @@ class ConstituencyViewTest(TestCase):
             '<li><a href="/candidates/view_answer/3">' +
             'Brigadier General Horace Bolsom</a> ' +
             '(Keep Royalty White, Rat Catching And Safe Sewage Residents Party / ' +
-            'Not participating)</li>',
+            '0 questions answered)</li>',
             html=True
         )

--- a/q_and_a/apps/constituencies/views.py
+++ b/q_and_a/apps/constituencies/views.py
@@ -55,12 +55,13 @@ def HomePageView(request):
 
 def ConstituencyView(request, wmc_id):
     candidates = Candidate.objects.filter(constituency_id=wmc_id)
-    if not candidates:
-        raise Http404("Constituency not found")
     try:
         wmc_name = Constituency.objects.get(constituency_id=wmc_id).name
     except Constituency.DoesNotExist:
-        wmc_name = candidates.first().constituency_name
+        try:
+            wmc_name = candidates.first().constituency_name
+        except AttributeError:
+            raise Http404("Constituency not found")
 
     return render(request, 'constituency.html', {
         'constituency': wmc_name,


### PR DESCRIPTION
This repairs tests that were broken by recent changes. In one case it also fixes new functionality that wasn't implemented correctly - which would have been revealed by running the tests. (It is possible for a constituency to exist even if it has no candidates). I had also left a bookmark in a functional test that made it fail deliberately, which this patch removes.

Please can we make sure the tests pass before committing to master in future?

`$ python manage.py test` is our friend :smile_cat: 
